### PR TITLE
test: expand test coverage for blueprints, validation errors, and observers

### DIFF
--- a/test/blueprints_helpers_and_copywith_test.dart
+++ b/test/blueprints_helpers_and_copywith_test.dart
@@ -1,0 +1,199 @@
+import 'package:test/test.dart';
+import 'package:hierarchical_state_machine/src/machine.dart';
+
+enum States {
+  root,
+  sub,
+  choice,
+  fork,
+  parallel,
+  region1,
+  region2,
+  ending,
+  term,
+}
+
+enum Events { next, alt }
+
+void main() {
+  group('BasicBlueprintHelpers', () {
+    final composite = BasicBlueprint<States, Events>.composite(id: States.sub);
+    final parallel = BasicBlueprint<States, Events>.parallel(
+      id: States.parallel,
+    );
+    final choice = BasicBlueprint<States, Events>.choice(
+      id: States.choice,
+      defaultTransition: DefaultTransitionBlueprint.to(target: States.sub),
+    );
+    final fork = BasicBlueprint<States, Events>.fork(
+      id: States.fork,
+      transitions: [
+        ForkTransitionBlueprint.to(target: States.region1),
+        ForkTransitionBlueprint.to(target: States.region2),
+      ],
+    );
+    final finalState = BasicBlueprint<States, Events>.finish(id: States.ending);
+    final terminateState = BasicBlueprint<States, Events>.terminate(
+      id: States.term,
+    );
+
+    test('isComposite and asComposite', () {
+      expect(composite.isComposite, isTrue);
+      expect(parallel.isComposite, isTrue); // Parallel inherits Composite
+      expect(choice.isComposite, isFalse);
+
+      expect(composite.asComposite.id, States.sub);
+    });
+
+    test('isParallel and asParallel', () {
+      expect(parallel.isParallel, isTrue);
+      expect(composite.isParallel, isFalse);
+
+      expect(parallel.asParallel.id, States.parallel);
+      expect(() => composite.asParallel, throwsA(isA<TypeError>()));
+    });
+
+    test('isChoice and asChoice', () {
+      expect(choice.isChoice, isTrue);
+      expect(composite.isChoice, isFalse);
+
+      expect(choice.asChoice.id, States.choice);
+      expect(() => composite.asChoice, throwsA(isA<TypeError>()));
+    });
+
+    test('isFork and asFork', () {
+      expect(fork.isFork, isTrue);
+      expect(composite.isFork, isFalse);
+
+      expect(fork.asFork.id, States.fork);
+      expect(() => composite.asFork, throwsA(isA<TypeError>()));
+    });
+
+    test('isFinal and asFinal', () {
+      expect(finalState.isFinal, isTrue);
+      expect(composite.isFinal, isFalse);
+
+      expect(finalState.asFinal.id, States.ending);
+      expect(() => composite.asFinal, throwsA(isA<TypeError>()));
+    });
+
+    test('isTerminate and asTerminate', () {
+      expect(terminateState.isTerminate, isTrue);
+      expect(composite.isTerminate, isFalse);
+
+      expect(terminateState.asTerminate.id, States.term);
+      expect(() => composite.asTerminate, throwsA(isA<TypeError>()));
+    });
+  });
+
+  group('Blueprint copyWith methods', () {
+    test('DefaultTransitionBlueprintX.copyWith', () {
+      final original = DefaultTransitionBlueprint<States, Events>.to(
+        target: States.sub,
+        kind: TransitionKind.local,
+      );
+
+      final copy = original.copyWith(
+        target: States.ending,
+        action: (to: (e, d) {}),
+        kind: TransitionKind.external,
+        history: HistoryType.shallow,
+      );
+
+      expect(copy.target, States.ending);
+      expect(copy.action, isNotNull);
+      expect(copy.kind, TransitionKind.external);
+      expect(copy.history, HistoryType.shallow);
+
+      final copyNullAction = copy.copyWith(action: (to: null));
+      expect(copyNullAction.action, isNull);
+    });
+
+    test('ForkTransitionBlueprintX.copyWith', () {
+      final original = ForkTransitionBlueprint<States, Events>.to(
+        target: States.region1,
+      );
+
+      final copy = original.copyWith(
+        target: States.region2,
+        action: (to: (e, d) {}),
+        history: HistoryType.deep,
+      );
+
+      expect(copy.target, States.region2);
+      expect(copy.action, isNotNull);
+      expect(copy.history, HistoryType.deep);
+
+      final copyNullAction = copy.copyWith(action: (to: null));
+      expect(copyNullAction.action, isNull);
+    });
+
+    test('CompletionBlueprintX.copyWith', () {
+      final original = CompletionBlueprint<States, Events>.to(
+        target: States.sub,
+        guard: () => true,
+      );
+
+      final copy = original.copyWith(
+        target: (to: States.ending),
+        guard: (to: () => false),
+        action: (to: () {}),
+        kind: TransitionKind.external,
+        history: HistoryType.shallow,
+      );
+
+      expect(copy.target, States.ending);
+      expect(copy.guard?.call(), isFalse);
+      expect(copy.action, isNotNull);
+      expect(copy.kind, TransitionKind.external);
+      expect(copy.history, HistoryType.shallow);
+
+      final copyNull = copy.copyWith(
+        target: (to: null),
+        guard: (to: null),
+        action: (to: null),
+      );
+      expect(copyNull.target, isNull);
+      expect(copyNull.guard, isNull);
+      expect(copyNull.action, isNull);
+    });
+
+    test('ChoiceBlueprintX.copyWith', () {
+      final original = ChoiceBlueprint<States, Events>(
+        id: States.choice,
+        defaultTransition: DefaultTransitionBlueprint.to(target: States.sub),
+      );
+
+      final updatedDefault = DefaultTransitionBlueprint<States, Events>.to(
+        target: States.ending,
+      );
+      final copy = original.copyWith(
+        id: States.root,
+        defaultTransition: updatedDefault,
+        options: [TransitionBlueprint.to(target: States.parallel)],
+      );
+
+      expect(copy.id, States.root);
+      expect(copy.defaultTransition.target, States.ending);
+      expect(copy.options.length, 1);
+    });
+
+    test('ForkBlueprintX.copyWith', () {
+      final original = ForkBlueprint<States, Events>(
+        id: States.fork,
+        transitions: [ForkTransitionBlueprint.to(target: States.region1)],
+      );
+
+      final copy = original.copyWith(
+        id: States.root,
+        transitions: [
+          ForkTransitionBlueprint.to(target: States.region1),
+          ForkTransitionBlueprint.to(target: States.region2),
+        ],
+      );
+
+      expect(copy.id, States.root);
+      expect(copy.transitions.length, 2);
+    });
+  });
+}

--- a/test/validation_errors_and_observer_test.dart
+++ b/test/validation_errors_and_observer_test.dart
@@ -1,0 +1,126 @@
+import 'package:test/test.dart';
+import 'package:hierarchical_state_machine/src/machine.dart';
+
+enum States {
+  root,
+  sub,
+  choice,
+  fork,
+  parallel,
+  region1,
+  region2,
+  ending,
+  term,
+}
+
+enum Events { next, alt }
+
+class TestObserver<S, E> extends MachineObserver<S, E> {}
+
+Machine<States, Events> createTestMachine() {
+  final blueprint = MachineBlueprint<States, Events>(
+    root: .composite(
+      id: States.root,
+      children: [
+        .composite(id: States.sub),
+        .parallel(
+          id: States.parallel,
+          children: [
+            .composite(id: States.region1),
+            .composite(id: States.region2),
+          ],
+        ),
+      ],
+    ),
+  );
+  final (compiled, errors) = blueprint.compile();
+  expect(errors, isEmpty);
+  return compiled!;
+}
+
+void main() {
+  group('Validation Errors', () {
+    test('InvalidRootError formatting and properties', () {
+      final error = InvalidRootError();
+      expect(error.message, 'Root must be a State or ParallelState');
+      expect(
+        error.toString(),
+        'ValidationError: Root must be a State or ParallelState',
+      );
+    });
+
+    test('UnknownDefinitionTypeError formatting and properties', () {
+      final error = UnknownDefinitionTypeError<States>(String, States.sub);
+      expect(error.type, String);
+      expect(error.id, States.sub);
+      expect(
+        error.toString(),
+        'ValidationError: Unknown definition type "String" for state "States.sub"',
+      );
+    });
+  });
+
+  group('toString() representations', () {
+    test('EventHandler.toString() internal and external', () {
+      final machine = createTestMachine();
+      final targetState =
+          machine.getState(States.sub) as BaseState<States, Events>;
+
+      final handlerInternal = EventHandler<States, Events>(
+        guard: (e, d) => true,
+        action: (e, d) {},
+      );
+      expect(handlerInternal.toString(), contains('internal'));
+
+      final handlerExternal = EventHandler<States, Events>(
+        target: targetState,
+        kind: TransitionKind.external,
+      );
+      expect(handlerExternal.toString(), contains('TransitionKind.external'));
+    });
+
+    test('ForkTransition.toString()', () {
+      final machine = createTestMachine();
+      final targetState =
+          machine.getState(States.region1) as BaseState<States, Events>;
+      final transition = ForkTransition<States, Events>(
+        target: targetState,
+        history: HistoryType.shallow,
+      );
+      expect(transition.toString(), contains('ForkTransition'));
+      expect(transition.toString(), contains('shallow'));
+    });
+  });
+
+  group('MachineObserver Default Methods', () {
+    test('Base MachineObserver empty callbacks invoke cleanly', () {
+      final observer = TestObserver<States, Events>();
+      final machine = createTestMachine();
+      final st = machine.getState(States.root) as BaseState<States, Events>;
+
+      expect(() {
+        observer.onMachineStarting(machine);
+        observer.onMachineStarted(machine);
+        observer.onMachineStopped(machine);
+        observer.onMachineTerminated(machine);
+        observer.onEventQueued(machine, Events.next, null);
+        observer.onEventHandling(machine, Events.next, null);
+        observer.onEventHandled(st, Events.next, null);
+        observer.onEventUnhandled(st, Events.next, null);
+        observer.onEventDeferred(st, Events.next, null);
+        observer.onEventDropped(st, Events.next, null);
+        observer.onEventError(
+          machine,
+          Events.next,
+          null,
+          Exception('test'),
+          StackTrace.current,
+        );
+        observer.onStateEnter(st);
+        observer.onStateExit(st);
+        observer.onTransition(st, st, Events.next, null, TransitionKind.local);
+        observer.onInternalTransition(st, Events.next, null);
+      }, returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
## Description
Expands unit test coverage across blueprint helpers, validation errors, `copyWith` methods, `toString()` implementations, and base observer methods:
- Adds `test/blueprints_helpers_and_copywith_test.dart`
- Adds `test/validation_errors_and_observer_test.dart`

## Impact & Verification
- Total unit tests increased from 151 to 167 (all passing).
- Package line coverage increased from **90.8%** to **94.3%**.
- `errors.dart`: 81.2% ➔ 100.0%
- `event_handler.dart`: 42.9% ➔ 100.0%
- `transitions.dart`: 52.6% ➔ 86.8%
- `states.dart`: 82.8% ➔ 96.9%
- `observer.dart`: 90.2% ➔ 98.0%