### PR TITLE
feat(machine): provide Serializer<S,E> from machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 2026-07-01
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`hierarchical_state_machine` - `v2.4.0`](#hierarchical_state_machine---v240)
+
+---
+
+#### `hierarchical_state_machine` - `v2.4.0`
+
+ - **FIX**: allow duplicate events with guards in blueprint (#15).
+ - **FIX**: flutter's pinning of meta... (#12).
+ - **FEAT**(machine): provide Serializer<S,E> from machine.
+ - **FEAT**: add copyWith() functionality to blueprints (#16).
+ - **FEAT**: serialization and deserialization of machines (#11).
+ - **FEAT**: Export blueprints for rendering with PlantUML (#9).
+
+## 2.4.0
+
+ - **FIX**: allow duplicate events with guards in blueprint (#15).
+ - **FIX**: flutter's pinning of meta... (#12).
+ - **FEAT**(machine): provide Serializer<S,E> from machine.
+ - **FEAT**: add copyWith() functionality to blueprints (#16).
+ - **FEAT**: serialization and deserialization of machines (#11).
+ - **FEAT**: Export blueprints for rendering with PlantUML (#9).
+
 # Hierarchial State Machine
 
 ## 2.3.0

--- a/docs/api_surface.md
+++ b/docs/api_surface.md
@@ -217,6 +217,7 @@
   Stream<Machine<S, E>> onSettled;
   void Function()? onTerminated;
   HsmState<S, E> root;
+  Serializer<S, E> serializer;
   Future<void> settled;
   String stateString;
 ```

--- a/lib/src/machine.dart
+++ b/lib/src/machine.dart
@@ -138,6 +138,9 @@ final class Machine<S, E> {
   Future<void> get settled =>
       _eventQueue.isEmpty ? Future.value() : onSettled.first;
 
+  /// Returns a serializer for this machine.
+  Serializer<S, E> get serializer => Serializer<S, E>();
+
   /// Prepends work to the front of the event queue.
   ///
   /// Used for replaying deferred events when a state is exited.

--- a/lib/src/serializer.dart
+++ b/lib/src/serializer.dart
@@ -1,7 +1,7 @@
 part of 'machine.dart';
 
 /// Serialize a hierarchial state machine for storage.
-class Serializer<S, E extends Object> {
+class Serializer<S, E> {
   /// Serializes [hsm] to a string for offline storage.
   ///
   /// This call waits for the machine to be settled.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,3 +36,6 @@ dev_dependencies:
   melos: ^8.0.0
   path: ^1.9.1
   test: ^1.31.1
+
+melos:
+  useRootAsPackage: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ description: >-
   A performant state machine framework inspired by UML.
   Hierarchical parent/child states enable shared event
   handling for cleaner, more efficient logic.
-version: 2.3.0
+version: 2.4.0
 homepage: https://github.com/jtmcdole/hierarchical-state-machine.dart
 
 environment:

--- a/test/serializer_test.dart
+++ b/test/serializer_test.dart
@@ -70,4 +70,41 @@ void main() {
     expect(m2.stateString, contains('r1_b'));
     expect(m2.stateString, contains('r2_a'));
   });
+
+  test('Machine exposes serializer that can encode/decode', () async {
+    final blueprint = MachineBlueprint<String, String>(
+      name: 'ExposeSerializerTest',
+      root: .composite(
+        id: 'root',
+        initial: 'a',
+        children: [
+          .composite(
+            id: 'a',
+            on: {'go_b': .to(target: 'b')},
+          ),
+          .composite(id: 'b'),
+        ],
+      ),
+    );
+
+    final (m1, _) = blueprint.compile();
+    m1!.start();
+    await m1.handle('go_b');
+
+    // Access serializer directly from machine
+    final serializer = m1.serializer;
+    final json = await serializer.encode(m1);
+
+    final (m2, _) = blueprint.compile();
+    await m2!.serializer.decode(
+      m2,
+      json,
+      stateFactory: (id) => id as String,
+      eventFactory: (e) => e as String,
+      dataFactory: (d) => d,
+    );
+
+    expect(m2.isRunning, isTrue);
+    expect(m2.stateString, contains('b'));
+  });
 }


### PR DESCRIPTION
Exposes a `serializer` getter directly on the `Machine` class and relaxes the `E extends Object` constraint on `Serializer` to match `Machine`'s unbound event type parameter `E`.

fixes #1